### PR TITLE
chore: enhance slack pr notification

### DIFF
--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -11,5 +11,5 @@ jobs:
       - name: Slack Notification
         uses: rtCamp/action-slack-notify@master
         env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_FRONT }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_BACK }}
           SLACK_MESSAGE: "${{ github.event.pull_request.title }} - https://github.com/effectussoftware/pis-effectus-app/pull/${{ github.event.pull_request.number }}"


### PR DESCRIPTION
Enhance the slack pr notifications so they happen not only when a pr is created but when code is pushed to the pr.
It also adds a message to the notification with the title of the pr and a link to it since the current link is to the action and not the PR