### PR TITLE
fix: slack notify repo url

### DIFF
--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -1,6 +1,6 @@
 on:
   pull_request:
-    types: [open, synchronize]
+    types: [opened, synchronize]
 name: Slack Notification App
 jobs:
   slackNotification:


### PR DESCRIPTION
The repo url was wrong from doing copy paste