### PR TITLE
Add communications recurrent to feed. Fix on recurrent_from_date_hour…

### DIFF
--- a/app/controllers/api/v1/feeds_controller.rb
+++ b/app/controllers/api/v1/feeds_controller.rb
@@ -3,15 +3,13 @@
 module Api
   module V1
     class FeedsController < Api::V1::ApiController
-
-
       def show
         start = params[:start] ? Time.zone.parse(params[:start]) : Time.zone.now
         with_include = params[:include] || false
         communications = communication_not_recurrent(start, with_include)
         communications_recurrent = communication_recurrent(start)
         reviews = reviews(start, with_include)
-        @feeds = create_feed(communications, communications_recurrent ,reviews)
+        @feeds = create_feed(communications, communications_recurrent, reviews)
       end
 
       private

--- a/app/controllers/api/v1/feeds_controller.rb
+++ b/app/controllers/api/v1/feeds_controller.rb
@@ -3,12 +3,15 @@
 module Api
   module V1
     class FeedsController < Api::V1::ApiController
+
+
       def show
         start = params[:start] ? Time.zone.parse(params[:start]) : Time.zone.now
         with_include = params[:include] || false
         communications = communication_not_recurrent(start, with_include)
+        communications_recurrent = communication_recurrent(start)
         reviews = reviews(start, with_include)
-        @feeds = create_feed(communications, reviews)
+        @feeds = create_feed(communications, communications_recurrent ,reviews)
       end
 
       private
@@ -21,9 +24,17 @@ module Api
         Communication.not_recurrent_from_date(start_time, with_include).order(updated_at: :desc).limit(10)
       end
 
-      def create_feed(communications, reviews)
+      def communication_recurrent(start_time)
+        Communication.recurrent_from_date_hour(start_time)
+      end
+
+      def create_feed(communications, communications_recurrent, reviews)
         feed = communications.map do |communication|
           Feed.from_communication(communication)
+        end
+
+        feed += communications_recurrent.map do |communication_recurrent|
+          Feed.from_communication_recurrent(communication_recurrent)
         end
 
         feed += reviews.map do |review|

--- a/app/models/communication.rb
+++ b/app/models/communication.rb
@@ -30,7 +30,8 @@ class Communication < ApplicationRecord
     where(query, start_time)
   }
   scope :recurrent_from_date_hour, lambda { |requested_time|
-    where("to_char(recurrent_on, 'MMDDHH') = to_char(?::TIMESTAMP, 'MMDDHH')", requested_time)
+    where("to_char(communications.recurrent_on, 'MMDDHH24') = to_char(?::TIMESTAMP, 'MMDDHH24')  AND
+      communications.published = true", requested_time)
   }
 
   def image_url

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -14,6 +14,17 @@ class Feed
         image: image)
   end
 
+  def self.from_communication_recurrent(communication)
+    image = communication.image.attached? ? communication.image_url : nil
+
+    new(id: communication.id,
+        title: communication.title,
+        text: communication.text,
+        type: 'communication_recurrent',
+        updated_at: communication.recurrent_on.change(year: Date.today.year),  
+        image: image)
+  end
+
   def self.from_review(review)
     new(id: review.id,
         title: review.title,

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -21,7 +21,7 @@ class Feed
         title: communication.title,
         text: communication.text,
         type: 'communication_recurrent',
-        updated_at: communication.recurrent_on.change(year: Date.today.year),  
+        updated_at: communication.recurrent_on.change(year: Date.today.year),
         image: image)
   end
 


### PR DESCRIPTION
… function.

#### Trello ticket:
https://trello.com/c/qxWH5zSP/76-cuando-se-publica-un-comunicado-recurrente-para-el-mismo-d%C3%ADa-que-es-la-recurrencia-este-no-aparece-en-el-feed

------
#### How I solved it:

Fix query recurrent_from_date_hour from **app/models/communication.rb**
Add function **from_communication_recurrent** on **app/models/feed.rb** in order to parse communication into feed mapping recurrent_on field to updated_at (Using current year) 

------
#### Refactors or changes not directly related to the main purpose of this PR:


------
#### Screenshots:


------
#### API expected request/response:
