### PR TITLE
Fix: Not notify on recurrent communication created. User: communicati…

### DIFF
--- a/app/controllers/api/v1/communications_controller.rb
+++ b/app/controllers/api/v1/communications_controller.rb
@@ -10,7 +10,7 @@ module Api
       private
 
       def set_communication
-        @communication = Communication.published_and_not_recurrent.find(params[:id])
+        @communication = Communication.published.not_recurrent.find(params[:id])
       end
     end
   end

--- a/app/models/communication.rb
+++ b/app/models/communication.rb
@@ -9,12 +9,12 @@ class Communication < ApplicationRecord
   has_one_base64_attached :image
 
   validate :cant_update_if_published
-  after_save :send_notification, if: :just_published
+  after_save :send_notification, if: :can_notify
   before_destroy :cant_destroy_if_published_not_recurrent
 
   scope :published, -> { where(published: true) }
 
-  scope :published_and_not_recurrent, -> { where(published: true, recurrent_on: nil) }
+  scope :not_recurrent, -> { where(recurrent_on: nil) }
 
   scope :not_dummy, -> { where(dummy: false) }
 
@@ -60,12 +60,14 @@ class Communication < ApplicationRecord
   end
 
   def send_notification
-    return false if recurrent_on
-
     User.active.send_notification(title, text, { id: id, updated_at: updated_at, type: self.class.to_s })
   end
 
   def just_published
     saved_change_to_published? && published?
+  end
+
+  def can_notify
+    just_published and !recurrent_on
   end
 end


### PR DESCRIPTION
Fix: Not notify on recurrent communication created. User: communications/:id only show published and not recurrent Communications

#### Trello ticket:


------
#### How I solved it:


------
#### Refactors or changes not directly related to the main purpose of this PR:


------
#### Screenshots:


------
#### API expected request/response:
