### PR TITLE
fix: Remove user tokens when deactivated

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,8 @@ class User < ActiveRecord::Base
   include DeviseTokenAuth::Concerns::User
   alias devise_create_token create_token
 
+  before_save :destroy_sessions, unless: :is_active?
+
   scope :active, -> { where(is_active: true) }
 
   def create_token(client: nil, lifespan: nil, cost: nil, **token_extras)
@@ -50,5 +52,9 @@ class User < ActiveRecord::Base
       push_notification_tokens << token['push_notification_token'] if token['push_notification_token']
     end
     push_notification_tokens
+  end
+
+  def destroy_sessions
+    self.tokens = {}
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,6 +9,24 @@ RSpec.describe User, type: :model do
 
   let(:message) { 'message' }
 
+  describe 'before_saves' do
+    describe 'destroy_sessions' do
+      it 'destroys user sessions if account is deactivated' do
+        user = create(:user, is_active: true)
+        user.create_new_auth_token
+        expect(user.tokens).to_not eq({})
+        user.update(is_active: false)
+        expect(user.reload.tokens).to eq({})
+      end
+
+      it "can't create a new session if user is deactivated" do
+        user = create(:user, is_active: false)
+        user.create_new_auth_token
+        expect(user.reload.tokens).to eq({})
+      end
+    end
+  end
+
   describe '#send_notification' do
     before(:each) do
       allow(PushNotificationService).to receive(:send_notification).and_return(PUSH_NOTIFICATION_RESPONSE)

--- a/spec/requests/api/v1/admin/users_spec.rb
+++ b/spec/requests/api/v1/admin/users_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Users', type: :request do
+  let(:admin) { create(:admin) }
+  let(:user) { create(:user) }
+  let!(:auth_headers) { admin.create_new_auth_token }
+  let!(:user_auth_headers) { user.create_new_auth_token }
+
+  describe 'PUT api/v1/admin/users' do
+    it 'destroy user tokens if deactivated' do
+      data = { 'user': { 'is_active': false } }
+      expect(user.tokens).to_not eq({})
+      put api_v1_admin_user_path(user), headers: auth_headers, params: data
+      expect(response).to have_http_status 200
+      user.reload
+      expect(user.tokens).to eq({})
+    end
+  end
+end

--- a/spec/requests/api/v1/device_registrations_spec.rb
+++ b/spec/requests/api/v1/device_registrations_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'DeviceRegistrations', type: :request do
   describe '#create' do
     context 'with correct params' do
       it 'registers a new push_notification_token for the user within the corresponding client' do
-        user = create(:user)
+        user = create(:user, is_active: true)
         auth_headers = user.create_new_auth_token
         push_notification_token = 'sometoken111'
         post api_v1_device_registrations_path,
@@ -19,7 +19,7 @@ RSpec.describe 'DeviceRegistrations', type: :request do
 
     context 'with incorrect data' do
       it 'Returns 400 if token is missing' do
-        user = create(:user)
+        user = create(:user, is_active: true)
         auth_headers = user.create_new_auth_token
         post api_v1_device_registrations_path, headers: auth_headers
         expect(response).to have_http_status(400)


### PR DESCRIPTION
#### Trello ticket:

https://trello.com/c/T8odcI4U/57-al-dar-de-baja-a-un-usuario-con-sesi%C3%B3n-activa-no-lo-desloguea-de-la-app

------
#### How I solved it:

Agregué un before_save para que borre los tokens si está desactivado
