### PR TITLE
fix communication order

### DIFF
--- a/app/controllers/api/v1/admin/communications_controller.rb
+++ b/app/controllers/api/v1/admin/communications_controller.rb
@@ -60,7 +60,7 @@ module Api
         end
 
         def communications
-          Communication.not_dummy
+          Communication.includes([:image_attachment]).not_dummy.order(id: :desc)
         end
       end
     end

--- a/app/controllers/api/v1/admin/communications_controller.rb
+++ b/app/controllers/api/v1/admin/communications_controller.rb
@@ -60,7 +60,7 @@ module Api
         end
 
         def communications
-          Communication.includes([image_attachment: :blob]).not_dummy.order(id: :desc)
+          Communication.includes([{ image_attachment: :blob }]).not_dummy.order(id: :desc)
         end
       end
     end

--- a/app/controllers/api/v1/admin/communications_controller.rb
+++ b/app/controllers/api/v1/admin/communications_controller.rb
@@ -60,7 +60,7 @@ module Api
         end
 
         def communications
-          Communication.includes([:image_attachment]).not_dummy.order(id: :desc)
+          Communication.includes([image_attachment: :blob]).not_dummy.order(id: :desc)
         end
       end
     end

--- a/spec/requests/api/v1/admin/communications/create_spec.rb
+++ b/spec/requests/api/v1/admin/communications/create_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe 'Communications', type: :request do
         created_communication = Communication.first
         expect(created_communication.title).to eq 'Lala'
         expect(created_communication.text).to eq 'Lele'
-        expect(created_communication.recurrent_on).to eq '2020-10-28T19:18:36.662Z'
+        expect(created_communication.recurrent_on.to_s).to eq '2020-10-28'
       end
     end
 

--- a/spec/requests/api/v1/admin/communications/create_spec.rb
+++ b/spec/requests/api/v1/admin/communications/create_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe 'Communications', type: :request do
         created_communication = Communication.first
         expect(created_communication.title).to eq 'Lala'
         expect(created_communication.text).to eq 'Lele'
-        expect(created_communication.recurrent_on.to_s).to eq '2020-10-28'
+        expect(created_communication.recurrent_on).to eq '2020-10-28T19:18:36.662Z'
       end
     end
 

--- a/spec/requests/api/v1/admin/communications/index_spec.rb
+++ b/spec/requests/api/v1/admin/communications/index_spec.rb
@@ -9,11 +9,11 @@ RSpec.describe 'Communications index', type: :request do
 
   describe 'GET api/v1/admin/communications' do
     context 'with authorization' do
-      it 'returns the first 20 communications' do
+      it 'returns the last 20 communications' do
         get '/api/v1/admin/communications', headers: auth_headers
         expect(response).to have_http_status 200
         response_body = Oj.load(response.body)
-        expect(response_body['communications']).to eq(communications[0..19]
+        expect(response_body['communications']).to eq(communications[20..39].reverse
         .as_json(
           only: %i[id title text published recurrent_on created_at updated_at]
         ))
@@ -23,7 +23,7 @@ RSpec.describe 'Communications index', type: :request do
         get '/api/v1/admin/communications?page=2', headers: auth_headers
         expect(response).to have_http_status 200
         response_body = Oj.load(response.body)
-        expect(response_body['communications']).to eq(communications[20..39]
+        expect(response_body['communications']).to eq(communications[0..19].reverse
         .as_json(
           only: %i[id title text published recurrent_on created_at updated_at]
         ))
@@ -33,7 +33,7 @@ RSpec.describe 'Communications index', type: :request do
         get '/api/v1/admin/communications?page=1&per_page=10', headers: auth_headers
         expect(response).to have_http_status 200
         response_body = Oj.load(response.body)
-        communications_expected = communications[0..9]
+        communications_expected = communications[30..39].reverse
         expect(response_body['communications']).to eq(communications_expected
         .as_json(
           only: %i[id title text published recurrent_on created_at updated_at]
@@ -45,7 +45,7 @@ RSpec.describe 'Communications index', type: :request do
         expect(response).to have_http_status 200
         response_body = Oj.load(response.body)
         communications_published = communications.select(&:published)
-        expect(response_body['communications']).to eq(communications_published[0..19]
+        expect(response_body['communications']).to eq(communications_published[0..19].reverse
         .as_json(
           only: %i[id title text published recurrent_on created_at updated_at]
         ))

--- a/spec/requests/api/v1/admin/communications/index_spec.rb
+++ b/spec/requests/api/v1/admin/communications/index_spec.rb
@@ -44,8 +44,8 @@ RSpec.describe 'Communications index', type: :request do
         get '/api/v1/admin/communications?published=true', headers: auth_headers
         expect(response).to have_http_status 200
         response_body = Oj.load(response.body)
-        communications_published = communications.select(&:published)
-        expect(response_body['communications']).to eq(communications_published[0..19].reverse
+        communications_published = communications.select(&:published).reverse
+        expect(response_body['communications']).to eq(communications_published[0..19]
         .as_json(
           only: %i[id title text published recurrent_on created_at updated_at]
         ))


### PR DESCRIPTION
#### Trello ticket:
Los comunicados se listan al reves en el dashboard.

------
#### How I solved it:


------
#### Refactors or changes not directly related to the main purpose of this PR:


------
#### Screenshots:


------
#### API expected request/response:
