### PR TITLE
fix: recurrent communication notification sent twice

### DIFF
--- a/app/models/communication.rb
+++ b/app/models/communication.rb
@@ -31,8 +31,9 @@ class Communication < ApplicationRecord
 
     where(query, start_time)
   }
+
   scope :recurrent_from_date_hour, lambda { |requested_time|
-    where("to_char(recurrent_on, 'MMDDHH') = to_char(?::TIMESTAMP, 'MMDDHH')", requested_time)
+    where("to_char(recurrent_on, 'MMDDHH24') = to_char(?::TIMESTAMP, 'MMDDHH24')", requested_time)
   }
 
   def image_url

--- a/config/database.yml
+++ b/config/database.yml
@@ -37,7 +37,6 @@ production:
   username: <%= ENV.fetch('DATABASE_USERNAME', 'carl') %>
   password: <%= ENV.fetch('DATABASE_PASSWORD', '') %>
 
-
 staging:
   <<: *default
   database: pis_effectus_api_staging

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -53,9 +53,6 @@ ActiveRecord::Schema.define(version: 2020_10_27_225045) do
     t.integer "user_review_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-
-    t.index ["reviewer_review_id"], name: "index_review_action_item_on_reviewer_review_id"
-    t.index ["user_review_id"], name: "index_review_action_item_user_review_id"
   end
 
   create_table "reviews", force: :cascade do |t|


### PR DESCRIPTION
#### Trello ticket:
[Los comunicados recurrentes están publicandose 2 veces al día](https://trello.com/c/iKT7MoBY/91-los-comunicados-recurrentes-est%C3%A1n-publicandose-2-veces-al-d%C3%ADa)

------
#### How I solved it:
Se agregó al formato de hora usado para el scope que sea en base 24 hs en vez de 12 hs ya que al correr la taks `push_notifications:send_to_recurrent_communications`, si habia un comunicado recurrente con fecha de recurrencia de hoy pero hace 12 hs, también se mandaba la push cuando no debía.

------
#### Refactors or changes not directly related to the main purpose of this PR:
Las lineas que se remueven el en schema es porque hay una migración que todavia no está mergeada a master que las agrega, no sabemos como llegaron a master sin mergear esa migración. Cuando se mergee el otro PR volverán.
