### PR TITLE
Fix delete action items from reviews. Add test for update reviews.

### DIFF
--- a/app/controllers/api/v1/admin/reviews_controller.rb
+++ b/app/controllers/api/v1/admin/reviews_controller.rb
@@ -37,8 +37,8 @@ module Api
         def update_review_params
           params.require(:review)
                 .permit(:title, :comments,
-                        user_action_items_attributes: %i[id description completed],
-                        reviewer_action_items_attributes: %i[id description completed])
+                        user_action_items_attributes: %i[id description completed _destroy],
+                        reviewer_action_items_attributes: %i[id description completed _destroy])
         end
 
         def create_review_params

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -14,8 +14,8 @@ class Review < ApplicationRecord
            class_name: 'ReviewActionItem',
            dependent: :delete_all
 
-  accepts_nested_attributes_for :user_action_items
-  accepts_nested_attributes_for :reviewer_action_items
+  accepts_nested_attributes_for :user_action_items, allow_destroy: true
+  accepts_nested_attributes_for :reviewer_action_items, allow_destroy: true
 
   validates :title, presence: true
   validate  :cant_save_if_reviewer_is_not_admin


### PR DESCRIPTION
#### Trello ticket:
[Al apretar click en editar una 1o1, no puedo borrar los items de las checklist.](https://trello.com/c/kdWgmdD2)
------
#### How I solved it:
Added param _destroy in reviews' nested attributes review_action_items and user_action_items. Added tests for this.

------
#### Refactors or changes not directly related to the main purpose of this PR:


------
#### Screenshots:


------
#### API expected request/response:
Request:
`
{
    "review": {
        "id": 2,
        "reviewer_id": 1,
        "user_id": 1,
        "title": "APrimera 1o1",
        "comments": "Acomeddasdnt",
        "user_action_items_attributes": [
            {
                "id": 9,
                "_destroy": true
            }
        ]
    }
}
`
Response:
`
{
    "review": {
        "id": 2,
        "reviewer_id": 1,
        "user_id": 1,
        "title": "APrimera 1o1",
        "comments": "Acomeddasdnt",
        "user_action_items": []
    }
}
`

