### PR TITLE
add cancelled to feed

### DIFF
--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -11,6 +11,7 @@ class Feed
               :updated_at,
               :image,
               :changed_last_seen,
+              :cancelled,
               :attend,
               :confirmation
 
@@ -43,11 +44,12 @@ class Feed
         type: event.class.to_s,
         updated_at: event.updated_event_at,
         changed_last_seen: invitation.new_updates_since_last_seen?,
+        cancelled: event.cancelled,
         attend: invitation.attend,
         confirmation: invitation.confirmation)
   end
 
-  def initialize(args)
+  def initialize(args) # rubocop:disable Metrics/AbcSize
     @id =  args[:id]
     @title = args[:title]
     @address = args[:address]
@@ -58,6 +60,7 @@ class Feed
     @updated_at = args[:updated_at]
     @image = args[:image]
     @changed_last_seen = args[:changed_last_seen]
+    @cancelled = args[:cancelled]
     @attend = args[:attend]
     @confirmation = args[:confirmation]
   end

--- a/app/views/api/v1/feeds/_feed.json.jbuilder
+++ b/app/views/api/v1/feeds/_feed.json.jbuilder
@@ -11,5 +11,6 @@ json.extract! feed,
               :updated_at,
               :image,
               :changed_last_seen,
+              :cancelled,
               :attend,
               :confirmation

--- a/spec/requests/api/v1/feed/show_spec.rb
+++ b/spec/requests/api/v1/feed/show_spec.rb
@@ -48,7 +48,8 @@ RSpec.describe 'Feed', type: :request do
             end_time: item['end_time'],
             changed_last_seen: item['changed_last_seen'],
             start_time: item['start_time'],
-            confirmation: item['confirmation']
+            confirmation: item['confirmation'],
+            cancelled: item['cancelled']
           }.as_json
         end
         expect(feed_map).to eq(response_expected_map)


### PR DESCRIPTION
#### Trello ticket:
Agrego cancelled al feed para mostrar estados de eventos en el feed

------
#### How I solved it:


------
#### Refactors or changes not directly related to the main purpose of this PR:


------
#### Screenshots:


------
#### API expected request/response:
