### PR TITLE
not send push on cancelled events

### DIFF
--- a/lib/tasks/push_notifications.rake
+++ b/lib/tasks/push_notifications.rake
@@ -9,7 +9,7 @@ namespace :push_notifications do
 
   desc 'sends a push notification to all users that have not yet replied 2 days before the event starts'
   task send_48_hour_reminder: :environment do
-    events = Event.on_day(2.days.from_now)
+    events = Event.where(cancelled: false).on_day(2.days.from_now)
     events.each do |event|
       event.invitations.not_confirmed.each(&:send_48_hour_reminder)
     end


### PR DESCRIPTION
#### Trello ticket:


------
#### How I solved it:
Se arregla que no se manden push njotifications por eventos cancelados

------
#### Refactors or changes not directly related to the main purpose of this PR:


------
#### Screenshots:


------
#### API expected request/response:
