### PR TITLE
Fix/validations start time end time events

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -44,11 +44,14 @@ class Event < ApplicationRecord
   end
 
   def end_time_must_be_greater_than_start_time
-    errors.add(:start_time, 'end_time must be greater than start_time') if check_end_time_and_start_time
+    return unless check_end_time_and_start_time && public_fields_would_update?
+    errors.add(:start_time, 'end_time must be greater than start_time')
   end
 
   def end_time_and_start_time_must_be_greater_than_now
-    errors.add(:start_time, 'end_time and start_time must be greater than now') if start_time_end_time_greater_than_now
+    return unless start_time_end_time_greater_than_now && public_fields_would_update?
+
+    errors.add(:start_time, 'end_time and start_time must be greater than now')
   end
 
   def check_end_time_and_start_time

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -45,6 +45,7 @@ class Event < ApplicationRecord
 
   def end_time_must_be_greater_than_start_time
     return unless check_end_time_and_start_time && public_fields_would_update?
+
     errors.add(:start_time, 'end_time must be greater than start_time')
   end
 

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -43,6 +43,18 @@ RSpec.describe Event, type: :model do
     end
   end
 
+  describe 'updates the privates fields without check the start_time and end_time validations' do
+    it 'updates the event cost with start_time < Time.zone.now' do
+      event = nil
+      Timecop.freeze(Date.today - 1.hour) do
+        event = create(:event, cost: 100, start_time: Time.zone.now, end_time: Time.zone.now + 2.hour)
+      end
+      Timecop.freeze(Date.today) do
+        expect { event.update(cost: 200) }.to change(event, :cost).to 200
+      end
+    end
+  end
+
   describe '.set_updated_event_at' do
     it 'updates updated_event_at when public fields are changed' do
       event = nil


### PR DESCRIPTION
#### Trello ticket:
https://trello.com/c/Rr1XGJw8/138-al-crear-o-actualizar-un-evento-este-debe-cumplir-que-starttime-endtime-y-starttime-timezonenow

------
#### How I solved it:
Se agrega que se validen las fechas si los campos publicos son modificados

------
#### Refactors or changes not directly related to the main purpose of this PR:


------
#### Screenshots:


------
#### API expected request/response:
