### PR TITLE
priority feed added

### DIFF
--- a/app/controllers/api/v1/priority_feeds_controller.rb
+++ b/app/controllers/api/v1/priority_feeds_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class PriorityFeedsController < Api::V1::ApiController
+      def show
+        @feeds = create_feed(events)
+      end
+
+      private
+
+      def events
+        Event.future.joins(:invitations).where(
+          'invitations.user_id = ? AND NOT invitations.confirmation', current_user.id
+        ).order(
+          start_time: :desc
+        ).includes(:invitations)
+      end
+
+      def create_feed(events)
+        events.map do |event|
+          Feed.from_event(event, event.invitations.find_by(user: current_api_v1_user))
+        end
+      end
+    end
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -25,6 +25,7 @@ class Event < ApplicationRecord
     joins(:invitations).where(query, start_time, user_id)
   }
 
+  scope :future, -> { where('start_time > ?', Time.zone.now) }
   scope :on_month, lambda { |date, user_id|
     query = "to_char(events.start_time, 'YYYYMM') = to_char(?::TIMESTAMP,'YYYYMM') and invitations.user_id = ?"
     joins(:invitations).where(query, date, user_id).order(:start_time)

--- a/app/views/api/v1/priority_feeds/show.json.jbuilder
+++ b/app/views/api/v1/priority_feeds/show.json.jbuilder
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+json.feed do
+  json.partial! partial: 'api/v1/feeds/feed', collection: @feeds, as: :feed
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
       mount_devise_token_auth_for 'User', at: 'auth'
       post '/auth/login', to: 'authentication#login'
       resource :feed, only: %i[show]
+      resource :priority_feed, only: %i[show]
       resources :reviews, only: %i[index show]
       resources :communications, only: %i[show]
       resources :events, only: %i[index show]

--- a/spec/requests/api/v1/feed/show_spec.rb
+++ b/spec/requests/api/v1/feed/show_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'Feed', type: :request do
             title: item['title'] || item['name'],
             type: class_type,
             image: item['image'],
-            updated_at: item['event_updated_at'] || item['updated_at'],
+            updated_at: item['updated_event_at'] || item['updated_at'],
             address: item['address'],
             attend: item['attend'],
             end_time: item['end_time'],

--- a/spec/requests/api/v1/priority_feed/show_spec.rb
+++ b/spec/requests/api/v1/priority_feed/show_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Feed', type: :request do
+  # authorization
+  let!(:user) { create(:user) }
+  let!(:auth_headers) { user.create_new_auth_token }
+
+  describe 'GET api/v1/feed' do
+    context 'with authorization' do
+      it 'lists the events' do
+        create(:invitation, confirmation: true, user_id: user.id, event: create(
+          :event, start_time: Time.zone.now + 1.day
+        ))
+        invitation = create(:invitation, confirmation: false, user_id: user.id, event: create(
+          :event, start_time: Time.zone.now + 1.day
+        ))
+        Timecop.freeze(Time.zone.now - 1.day) do
+          create(:invitation, confirmation: true, user_id: user.id, event: create(:event, start_time: Time.zone.now))
+          create(:invitation, confirmation: false, user_id: user.id, event: create(:event, start_time: Time.zone.now))
+        end
+
+        get '/api/v1/priority_feed', headers: auth_headers
+        expect(response).to have_http_status 200
+
+        feed = Oj.load(response.body)['feed']
+        feed_map = feed.as_json
+
+        response_expected = [invitation.event]
+
+        response_expected_map = response_expected.map do |item|
+          class_type = item.class.to_s
+          item = item.as_json
+
+          invitation = Invitation.find_by(event_id: item['id'], user_id: user.id)
+          item['attend'] = invitation.attend
+          item['confirmation'] = invitation.confirmation
+          item['changed_last_seen'] = invitation.new_updates_since_last_seen?
+
+          {
+            id: item['id'],
+            text: item['text'],
+            title: item['name'],
+            type: class_type,
+            image: item['image'],
+            updated_at: item['updated_event_at'],
+            address: item['address'],
+            attend: item['attend'],
+            end_time: item['end_time'],
+            changed_last_seen: item['changed_last_seen'],
+            start_time: item['start_time'],
+            confirmation: item['confirmation'],
+            cancelled: item['cancelled']
+          }.as_json
+        end
+        expect(feed_map).to eq(response_expected_map)
+      end
+    end
+
+    context 'with no authorization' do
+      it 'returns 401' do
+        get '/api/v1/feed'
+        expect(response).to have_http_status 401
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### Trello ticket:
https://trello.com/c/WkMrLka5/29-como-usuario-debo-de-poder-ver-los-eventos-proximos-a-los-que-no-indiqu%C3%A9-asistencia-en-mi-feed-para-poder-tomar-acci%C3%B3n-rapida-so

------
#### How I solved it:
Se creo un endpoint GET para api/v1/priority_feed con una respuesta:


------
#### Refactors or changes not directly related to the main purpose of this PR:


------
#### Screenshots:


------
#### API expected request/response:
response :
{"feed": [
        {
            "id": 4,
            "title": "evento_nuevo",
            "text": null,
            "type": "Event",
            "address": "testing_address333",
            "start_time": "2020-12-09T17:00:00.000Z",
            "end_time": "2020-12-10T17:00:00.000Z",
            "updated_at": "2020-11-18T19:51:45.254Z",
            "image": null,
            "changed_last_seen": false,
            "cancelled": false,
            "attend": null,
            "confirmation": false
        }]
}