### PR TITLE
Fix/send notifications event

### DIFF
--- a/app/controllers/api/v1/admin/events_controller.rb
+++ b/app/controllers/api/v1/admin/events_controller.rb
@@ -20,7 +20,8 @@ module Api
 
         def update
           @event = Event.find(params[:id])
-          @event.update!(event_params)
+          @event.update!(event_params.except(:invitations_attributes))
+          @event.update!(event_params.slice(:invitations_attributes))
         end
 
         private

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -15,7 +15,7 @@ class Event < ApplicationRecord
 
   before_save :set_updated_event_at, if: :public_fields_would_update?
   after_save :send_notification, if: :just_published
-  after_update :notify_invited_users, if: :public_fields_updated?
+  after_update :notify_invited_users, if: %i[public_fields_updated? published]
 
   scope :from_date, lambda { |start_time, with_include, user_id|
     query = if with_include

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -14,7 +14,7 @@ class Event < ApplicationRecord
   validate :end_time_and_start_time_must_be_greater_than_now
 
   before_save :set_updated_event_at, if: :public_fields_would_update?
-  after_save :send_notification, if: :just_published
+  after_save :send_new_event_notification, if: :just_published
   after_update :notify_invited_users, if: %i[public_fields_updated? published]
 
   scope :from_date, lambda { |start_time, with_include, user_id|
@@ -91,7 +91,7 @@ class Event < ApplicationRecord
     saved_change_to_published? && published?
   end
 
-  def send_notification
+  def send_new_event_notification
     invitations.each(&:send_new_event_notification)
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -78,9 +78,9 @@ RSpec.describe Event, type: :model do
   end
 
   describe 'after an event is modified' do
-    it 'sends notification if public fields are updated' do
+    it 'sends notification if public fields are updated and the event is published' do
       Timecop.freeze(Time.zone.local(2020))
-      ev = create(:event)
+      ev = create(:event, published: true)
       user = create(:user)
       expect(user).to_not receive(:send_notification)
 
@@ -96,6 +96,15 @@ RSpec.describe Event, type: :model do
       end
       expect(ev.update(name: new_name)).to eq(true)
       Timecop.return
+    end
+
+    it 'must not send notification with a event not published' do
+      Timecop.freeze(Time.zone.local(2020))
+      ev = create(:event, published: false)
+      user = User.find(ev.invitations.first.user_id)
+      new_name = 'Nuevo titulo Editado'
+      expect(user).to_not receive(:send_notification)
+      expect(ev.update(name: new_name)).to eq true
     end
   end
 end


### PR DESCRIPTION
#### Trello ticket:
https://trello.com/c/s3naEPLN/139-al-crear-un-evento-y-se-invita-a-pis-llegan-dos-notificaciones-al-usuario-de-pis-loggeado-una-por-la-creacion-del-evento-y-otra

------
#### How I solved it:
Cambio de orden en la ejecución del update de eventos 

------
#### Refactors or changes not directly related to the main purpose of this PR:


------
#### Screenshots:


------
#### API expected request/response:
