### PR TITLE
fix/maximo costo para evento aumentado

### DIFF
--- a/db/migrate/20201122221426_change_precision_to_event_cost_field.rb
+++ b/db/migrate/20201122221426_change_precision_to_event_cost_field.rb
@@ -1,0 +1,5 @@
+class ChangePrecisionToEventCostField < ActiveRecord::Migration[6.0]
+  def change
+    change_column :events, :cost, :decimal, precision: 9, scale: 2
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_17_215104) do
+ActiveRecord::Schema.define(version: 2020_11_22_221426) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,7 +51,7 @@ ActiveRecord::Schema.define(version: 2020_11_17_215104) do
     t.string "address"
     t.datetime "start_time"
     t.datetime "end_time"
-    t.decimal "cost", precision: 7, scale: 2, default: "0.0"
+    t.decimal "cost", precision: 9, scale: 2, default: "0.0"
     t.datetime "updated_event_at"
     t.boolean "cancelled", default: false
     t.datetime "created_at", precision: 6, null: false


### PR DESCRIPTION
#### Trello ticket:
[https://trello.com/c/ZVREO7hK/152-el-m%C3%A1ximo-del-costo-es-99999-agregar-al-menos-2-d%C3%ADgitos-m%C3%A1s](url)

------
#### How I solved it:
se agrego una migracion para aumentar el valor de precision

------
#### Refactors or changes not directly related to the main purpose of this PR:


------
#### Screenshots:


------
#### API expected request/response:
