### PR TITLE
fix/event_cancelled_cant_be_updated_and_check_validations_times

### DIFF
--- a/app/controllers/api/v1/admin/events_controller.rb
+++ b/app/controllers/api/v1/admin/events_controller.rb
@@ -20,8 +20,10 @@ module Api
 
         def update
           @event = Event.find(params[:id])
-          @event.update!(event_params.except(:invitations_attributes))
-          @event.update!(event_params.slice(:invitations_attributes))
+          ActiveRecord::Base.transaction do
+            @event.update!(event_params.slice(:invitations_attributes))
+            @event.update!(event_params.except(:invitations_attributes))
+          end
         end
 
         private

--- a/app/models/communication.rb
+++ b/app/models/communication.rb
@@ -51,11 +51,11 @@ class Communication < ApplicationRecord
   private
 
   def cant_destroy_if_published_not_recurrent
-    throw :abort, "No es posible borrar un comunicado no recurrente ya publicado" if published_was && !recurrent_on_was
+    throw :abort, 'No es posible borrar un comunicado no recurrente ya publicado' if published_was && !recurrent_on_was
   end
 
   def cant_update_if_published
-    errors.add(:published, "No es posible actualizar un comunicado publicado") if published_was
+    errors.add(:published, 'No es posible actualizar un comunicado publicado') if published_was
   end
 
   def send_notification

--- a/app/models/communication.rb
+++ b/app/models/communication.rb
@@ -51,11 +51,11 @@ class Communication < ApplicationRecord
   private
 
   def cant_destroy_if_published_not_recurrent
-    throw :abort, "can't delete published non recurrent communications" if published_was && !recurrent_on_was
+    throw :abort, "No es posible borrar un comunicado no recurrente ya publicado" if published_was && !recurrent_on_was
   end
 
   def cant_update_if_published
-    errors.add(:published, "can't update communications once published") if published_was
+    errors.add(:published, "No es posible actualizar un comunicado publicado") if published_was
   end
 
   def send_notification

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -12,7 +12,7 @@ class Event < ApplicationRecord
   validate :invitations_not_empty
   validate :end_time_must_be_greater_than_start_time
   validate :end_time_and_start_time_must_be_greater_than_now
-  before_update :cant_update_if_cancelled_event
+  validate :cant_update_if_cancelled_event
 
   before_save :set_updated_event_at, if: :public_fields_would_update?
   after_save :send_new_event_notification, if: :just_published
@@ -75,7 +75,7 @@ class Event < ApplicationRecord
   private
 
   def cant_update_if_cancelled_event
-    throw :abort, "can't update cancelledevent" if cancelled_was
+    errors.add(:cancelled, 'No es posible actualizar un evento cancelado') if cancelled_was
   end
 
   def set_updated_event_at

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -17,7 +17,6 @@ class Event < ApplicationRecord
   before_save :set_updated_event_at, if: :public_fields_would_update?
   after_save :send_new_event_notification, if: :just_published
   after_update :notify_invited_users, if: %i[public_fields_updated? published]
-  
 
   scope :user_event_from_date_confirmed, lambda { |start_time, with_include, user_id|
     query = if with_include
@@ -85,7 +84,7 @@ class Event < ApplicationRecord
 
   def public_fields_would_update?
     name_changed? || address_changed? ||
-      start_time_changed? || end_time_changed? || cancelled_changed?
+      start_time_changed? || end_time_changed? || cancelled_changed? || published_changed?
   end
 
   def public_fields_updated?

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -13,6 +13,7 @@ class Event < ApplicationRecord
   validate :end_time_must_be_greater_than_start_time
   validate :end_time_and_start_time_must_be_greater_than_now
   validate :cant_update_if_cancelled_event
+  validate :can_update_published_field
 
   before_save :set_updated_event_at, if: :public_fields_would_update?
   after_save :send_new_event_notification, if: :just_published
@@ -76,6 +77,12 @@ class Event < ApplicationRecord
 
   def cant_update_if_cancelled_event
     errors.add(:cancelled, 'No es posible actualizar un evento cancelado') if cancelled_was
+  end
+
+  def can_update_published_field
+    return unless published_was && will_save_change_to_published?
+
+    errors.add(:published, 'No es posible cambiar el campo publicado del evento')
   end
 
   def set_updated_event_at

--- a/spec/models/communication_spec.rb
+++ b/spec/models/communication_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Communication, type: :model do
     it "can't be updated once published" do
       com = create(:communication, published: true)
       expect(com.update(title: 'new title')).to eq(false)
-      expect(com.errors[:published]).to include("can't update communications once published")
+      expect(com.errors[:published]).to include("No es posible actualizar un comunicado publicado")
       expect(com.update(published: false)).to eq(false)
     end
 

--- a/spec/models/communication_spec.rb
+++ b/spec/models/communication_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Communication, type: :model do
     it "can't be updated once published" do
       com = create(:communication, published: true)
       expect(com.update(title: 'new title')).to eq(false)
-      expect(com.errors[:published]).to include("No es posible actualizar un comunicado publicado")
+      expect(com.errors[:published]).to include('No es posible actualizar un comunicado publicado')
       expect(com.update(published: false)).to eq(false)
     end
 

--- a/spec/requests/api/v1/admin/communications/update_spec.rb
+++ b/spec/requests/api/v1/admin/communications/update_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe 'Communications', type: :request do
         communication_title = communication.title
         put "/api/v1/admin/communications/#{communication.id}", headers: auth_headers, params: data
         expect(response).to have_http_status 403
-        expect(Oj.load(response.body)['error']).to match("No es posible actualizar un comunicado publicado")
+        expect(Oj.load(response.body)['error']).to match('No es posible actualizar un comunicado publicado')
         communication.reload
         expect(communication.title).to eq(communication_title)
       end

--- a/spec/requests/api/v1/admin/communications/update_spec.rb
+++ b/spec/requests/api/v1/admin/communications/update_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe 'Communications', type: :request do
         communication_title = communication.title
         put "/api/v1/admin/communications/#{communication.id}", headers: auth_headers, params: data
         expect(response).to have_http_status 403
-        expect(Oj.load(response.body)['error']).to match("can't update communications once published")
+        expect(Oj.load(response.body)['error']).to match("No es posible actualizar un comunicado publicado")
         communication.reload
         expect(communication.title).to eq(communication_title)
       end

--- a/spec/requests/api/v1/admin/events/update_spec.rb
+++ b/spec/requests/api/v1/admin/events/update_spec.rb
@@ -85,6 +85,15 @@ RSpec.describe 'Event update endpoint', type: :request do
           expect(Time.zone.parse(event_response['updated_event_at'])).to eq(time)
         end
       end
+      
+      it 'does not update a cancelled event' do
+        cancelled_event = create(:event, cancelled: true)
+        put api_v1_admin_event_path(cancelled_event.id), params: event_data_update, headers: auth_headers
+        expect(response).to have_http_status(403)
+        expect(Oj.load(response.body)['error']).to match('No es posible actualizar un evento cancelado')
+        cancelled_event.reload
+        expect(cancelled_event.cancelled).to eq(true)
+      end
     end
   end
 end


### PR DESCRIPTION
#### Trello ticket:
https://trello.com/c/4iiPud9X/151-un-evento-despu%C3%A9s-de-cancelado-no-se-deber%C3%ADa-poder-poner-como-no-cancelado

https://trello.com/c/cqvcdE9B/143-al-actualizar-un-evento-con-las-fechas-digamos-starttime-endtime-o-starttime-timezonenow-si-este-es-publicado-no-deberia-permiti

------
#### How I solved it:
se agrego chequeo before_update
y se agrega published como campo publico

------
#### Refactors or changes not directly related to the main purpose of this PR:


------
#### Screenshots:


------
#### API expected request/response:
