### PR TITLE
change order events

### DIFF
--- a/app/controllers/api/v1/priority_feeds_controller.rb
+++ b/app/controllers/api/v1/priority_feeds_controller.rb
@@ -13,7 +13,7 @@ module Api
         Event.future.published.joins(:invitations).where(
           'invitations.user_id = ? AND NOT invitations.confirmation AND NOT cancelled', current_user.id
         ).order(
-          start_time: :desc
+          start_time: :asc
         ).includes(:invitations)
       end
 


### PR DESCRIPTION
#### Trello ticket:

https://trello.com/c/bYVtQS4a/156-en-el-feed-prioritario-los-eventos-deber%C3%ADan-estar-ordenados-de-m%C3%A1s-pr%C3%B3ximo-a-menos-pr%C3%B3ximo
------
#### How I solved it:
Cambie en el feed prioritario como se ordenan los eventos

------
#### Refactors or changes not directly related to the main purpose of this PR:


------
#### Screenshots:


------
#### API expected request/response:
