### PR TITLE
Eventos y one on ones deberían incluir 'updated_at' en el index.

### DIFF
--- a/app/views/api/v1/admin/reviews/_review.json.jbuilder
+++ b/app/views/api/v1/admin/reviews/_review.json.jbuilder
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-json.extract! review, :id, :reviewer_id, :user_id, :title, :comments, :created_at
+json.extract! review, :id, :reviewer_id, :user_id, :title, :comments, :created_at, :updated_at
 json.reviewer_action_items review.reviewer_action_items do |action_item|
   json.extract! action_item, :id, :description, :completed
 end

--- a/spec/requests/api/v1/admin/reviews/index_spec.rb
+++ b/spec/requests/api/v1/admin/reviews/index_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Post endpoint', type: :request do
   end
 
   def review_to_json(review)
-    rev = review.as_json(only: %i[id comments title reviewer_id user_id])
+    rev = review.as_json(only: %i[id comments title reviewer_id user_id updated_at])
 
     user_items = review.user_action_items.map { |x| action_item_to_json(x) }
     reviewer_items = review.reviewer_action_items.map { |x| action_item_to_json(x) }

--- a/spec/requests/api/v1/admin/reviews/show_spec.rb
+++ b/spec/requests/api/v1/admin/reviews/show_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Post endpoint', type: :request do
 
         response_body = Oj.load(response.body)
 
-        response_expected = review.as_json(only: %i[id comments title reviewer_id user_id])
+        response_expected = review.as_json(only: %i[id comments title reviewer_id user_id created_at updated_at])
         response_expected = response_expected.merge(
           'user_action_items' => [user_action_item.as_json(only: %i[id description completed])]
         ).merge(


### PR DESCRIPTION
#### Trello ticket:
Eventos y one on ones deberían incluir 'updated_at' en el index.

------
#### How I solved it:
Eventos ya tenía un updated_at, pero se llamaba updated_event_at.
Para las one on ones lo agregué en el partial.

------
