### PR TITLE
Fixes: Order costs by date. Allow to change currency of cancelled events.

### DIFF
--- a/app/controllers/api/v1/admin/cost_summaries_controller.rb
+++ b/app/controllers/api/v1/admin/cost_summaries_controller.rb
@@ -9,15 +9,20 @@ module Api
           @events = filter_events if params[:year]
           date_format = 'YYYY'
           date_format += 'MM' if params[:year]
-          @costs_pesos = @events.where(currency: 'pesos')
-                                .group("to_char(events.start_time, '#{date_format}')")
-                                .sum('cost')
-          @costs_dolares = @events.where(currency: 'dolares')
-                                  .group("to_char(events.start_time, '#{date_format}')")
-                                  .sum('cost')
+          @costs_pesos = get_costs('pesos', date_format)
+          @costs_dolares = get_costs('dolares', date_format)
         end
 
         private
+
+        def get_costs(currency, date_format)
+          costs = @events.where(currency: currency)
+                         .group("to_char(events.start_time, '#{date_format}')")
+                         .sum('cost')
+
+          costs.map { |date, cost| { date: date, cost: cost } }
+               .sort_by { |x| x[:date] }
+        end
 
         def filter_events
           return unless params[:year]

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -103,9 +103,9 @@ class Event < ApplicationRecord
 
   def can_only_update_cost
     attributes_to_remove = if cancelled_was
-                             %w[cost updated_at]
+                             %w[cost updated_at currency]
                            else
-                             %w[cost updated_at cancelled updated_event_at]
+                             %w[cost updated_at cancelled updated_event_at currency]
                            end
     public_attributes = self.class.attribute_names.reject { |attribute| attributes_to_remove.include?(attribute) }
     public_attributes.map! { |attribute| "will_save_change_to_#{attribute}?" }

--- a/app/views/api/v1/admin/cost_summaries/show.json.jbuilder
+++ b/app/views/api/v1/admin/cost_summaries/show.json.jbuilder
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 json.cost_summary do
-  json.pesos @costs_pesos do |date_cost|
-    json.extract! date_cost, :date, :cost
+  json.pesos do
+    json.array! @costs_pesos, :date, :cost
   end
-  json.dolares @costs_dolares do |date_cost|
-    json.extract! date_cost, :date, :cost
+  json.dolares do
+    json.array! @costs_dolares, :date, :cost
   end
 end

--- a/app/views/api/v1/admin/cost_summaries/show.json.jbuilder
+++ b/app/views/api/v1/admin/cost_summaries/show.json.jbuilder
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
 json.cost_summary do
-  json.pesos @costs_pesos do |date, cost|
-    json.date date
-    json.cost cost
+  json.pesos @costs_pesos do |date_cost|
+    json.extract! date_cost, :date, :cost
   end
-  json.dolares @costs_dolares do |date, cost|
-    json.date date
-    json.cost cost
+  json.dolares @costs_dolares do |date_cost|
+    json.extract! date_cost, :date, :cost
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -42,8 +42,8 @@ ActiveRecord::Schema.define(version: 2020_11_26_192355) do
     t.boolean "published", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.boolean "dummy", default: false
     t.datetime "recurrent_on"
+    t.boolean "dummy", default: false
   end
 
   create_table "events", force: :cascade do |t|

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -59,6 +59,17 @@ RSpec.describe Event, type: :model do
     end
   end
 
+  describe 'modificacion of cancelled events' do
+    it 'updates the event cost and currency if event is cancelled' do
+      event = create(:event, cost: 100, currency: 'pesos')
+      event.update(cancelled: false)
+      event.reload
+      expect { event.update(cost: 200, currency: 'dolares') }
+        .to change(event, :cost).to(200)
+                                .and change(event, :currency).to('dolares')
+    end
+  end
+
   describe '.set_updated_event_at' do
     it 'updates updated_event_at when public fields are changed' do
       event = nil

--- a/spec/requests/api/v1/admin/cost_summaries/show_spec.rb
+++ b/spec/requests/api/v1/admin/cost_summaries/show_spec.rb
@@ -66,6 +66,29 @@ RSpec.describe 'Event show endpoint', type: :request do
           expect(cost).to eq expected_costs_dolares[month].to_s
         end
       end
+
+      it 'returns costs ordered by month' do
+        year = (Time.zone.now + 1.year).strftime('%Y')
+        get api_v1_admin_cost_summary_path, headers: auth_headers, params: { 'year': year }
+        expect(response).to have_http_status(200)
+
+        summary_response_pesos = Oj.load(response.body)['cost_summary']['pesos']
+        summary_response_dolares = Oj.load(response.body)['cost_summary']['dolares']
+
+        expect(summary_response_pesos).to eq(summary_response_pesos.sort_by { |x| x['date'] })
+        expect(summary_response_dolares).to eq(summary_response_dolares.sort_by { |x| x['date'] })
+      end
+
+      it 'returns costs ordered by year' do
+        get api_v1_admin_cost_summary_path, headers: auth_headers
+        expect(response).to have_http_status(200)
+
+        summary_response_pesos = Oj.load(response.body)['cost_summary']['pesos']
+        summary_response_dolares = Oj.load(response.body)['cost_summary']['dolares']
+
+        expect(summary_response_pesos).to eq(summary_response_pesos.sort_by { |x| x['date'] })
+        expect(summary_response_dolares).to eq(summary_response_dolares.sort_by { |x| x['date'] })
+      end
     end
   end
 end


### PR DESCRIPTION
#### Trello ticket:
- Allow to change currency of cancelled events.
- Return costs sorted by date

------
#### How I solved it:


------
#### Refactors or changes not directly related to the main purpose of this PR:


------
#### Screenshots:


------
#### API expected request/response:
