### PR TITLE
fix: delete procfile that is lowercase

### DIFF
--- a/procfile
+++ b/procfile
@@ -1,2 +1,0 @@
-release: rails db:migrate
-web: bin/rails server -p ${PORT:-5000} -e $RAILS_ENV


### PR DESCRIPTION
There were two procfiles one capitalized, which resulted in an issue for case-insensitive file systems.
